### PR TITLE
Add softdepend list support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,7 +117,7 @@ classes/
 ### Intellij Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
 
-# *.iml
+*.iml
 # modules.xml
 # .idea/misc.xml
 # *.ipr

--- a/src/main/java/tech/ferus/gradle/spigot/SpigotGradleExtension.java
+++ b/src/main/java/tech/ferus/gradle/spigot/SpigotGradleExtension.java
@@ -36,6 +36,6 @@ public class SpigotGradleExtension {
     }
 
     void meta(@DelegatesTo(PluginMeta.class) Closure<?> closure) {
-        plugin.getProject().configure(this.plugin.getPluginMeta(), closure);
+        this.plugin.getProject().configure(this.plugin.getPluginMeta(), closure);
     }
 }

--- a/src/main/java/tech/ferus/gradle/spigot/meta/MetaItems.java
+++ b/src/main/java/tech/ferus/gradle/spigot/meta/MetaItems.java
@@ -30,6 +30,7 @@ public enum MetaItems {
     AUTHOR("author", false),
     AUTHORS("authors", false),
     DEPEND("depend", false),
+    SOFTDEPEND("softdepend", false)
     ;
 
     private final String id;

--- a/src/main/java/tech/ferus/gradle/spigot/meta/PluginMeta.java
+++ b/src/main/java/tech/ferus/gradle/spigot/meta/PluginMeta.java
@@ -82,6 +82,10 @@ public class PluginMeta {
         this.set(MetaItems.DEPEND, depend);
     }
 
+    public void setSoftDepend(final List<String> softDepend) {
+        this.set(MetaItems.SOFTDEPEND, softDepend);
+    }
+
     private void set(final MetaItems key, final Object value) {
         this.items.add(new MetaItem(key, value));
     }


### PR DESCRIPTION
This will add support for the softdepend list in Bukkit.

This allows the ability to depend on a plugin loading before this one IF it exists.